### PR TITLE
Show error message when compiling code results in no command blocks (#1)

### DIFF
--- a/js/compiler.js
+++ b/js/compiler.js
@@ -68,7 +68,7 @@ define( [
 
       var command = CT.summonPiles( blockPiles );
       if( command.length > 32500 ) {
-        this.ui.popin.show( "alert", {
+        app.ui.popin.show( "alert", {
           "title": "Error",
           "text": "Warning: summon command is too long! (" + command.length + " characters)"
         } );

--- a/js/compiler.js
+++ b/js/compiler.js
@@ -65,7 +65,7 @@ define( [
       var blockPiles = this.generateBlocks( output );
 
       console.log( "blockPiles", blockPiles );
-      if( blockPiles[0].blocks.length === 0 ) {
+      if( blockPiles.every( function( pile ){ return pile.blocks.length === 0 } ) ) {
         app.ui.popin.show( "alert", {
           "title": "Error",
           "text": "Compilation resulted in no command blocks."

--- a/js/compiler.js
+++ b/js/compiler.js
@@ -65,6 +65,13 @@ define( [
       var blockPiles = this.generateBlocks( output );
 
       console.log( "blockPiles", blockPiles );
+      if( blockPiles[0].blocks.length === 0 ) {
+        app.ui.popin.show( "alert", {
+          "title": "Error",
+          "text": "Compilation resulted in no command blocks."
+        } );
+        return "";
+      }
 
       var command = CT.summonPiles( blockPiles );
       if( command.length > 32500 ) {


### PR DESCRIPTION
Fixes #1. Also fixes a bug where the warning about the summon command being to long isn't shown.
