### PR TITLE
Fixed visited links lighting up in Manual

### DIFF
--- a/manual/css/manual.css
+++ b/manual/css/manual.css
@@ -52,7 +52,7 @@ p {
   line-height:1.5;
 }
 
-a, a:hover, a:visited {
+a, a:hover {
   color: #fff;
   text-decoration: underline;
 }


### PR DESCRIPTION
Currently, the links in the manual's sidebar will light up when they've been visited (CSS `:visited`).
This is probably a bug, which this PR fixes by removing those specific styles for `a:visited`, which don't seem to be important for anything else.